### PR TITLE
ci: check every pull request

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,0 +1,71 @@
+name: Setup Android build environment
+description: JDK, Gradle with caching, and the google-services.json the build needs to configure.
+
+inputs:
+  google-services-json-base64:
+    description: >-
+      Base64 of the real google-services.json. Optional: pull requests from forks
+      cannot read secrets, and this file is gitignored, so a placeholder stands in
+      when it is absent.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+    # The google-services plugin fails configuration outright without this file,
+    # so every job needs one. Fork PRs get a structurally valid placeholder: it is
+    # enough to configure and build, and nothing in CI talks to Firebase.
+    - name: Provide google-services.json
+      shell: bash
+      env:
+        GOOGLE_SERVICES_JSON_BASE64: ${{ inputs.google-services-json-base64 }}
+      run: |
+        if [ -n "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > app/google-services.json
+          echo "Using google-services.json from secret."
+        else
+          cat > app/google-services.json <<'JSON'
+        {
+          "project_info": {
+            "project_number": "000000000000",
+            "project_id": "memosly-ci-placeholder",
+            "storage_bucket": "memosly-ci-placeholder.appspot.com"
+          },
+          "client": [
+            {
+              "client_info": {
+                "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                "android_client_info": {
+                  "package_name": "com.whtis.memosly"
+                }
+              },
+              "oauth_client": [],
+              "api_key": [
+                {
+                  "current_key": "AIzaSyA0000000000000000000000000000000000"
+                }
+              ],
+              "services": {
+                "appinvite_service": {
+                  "other_platform_oauth_client": []
+                }
+              }
+            }
+          ],
+          "configuration_version": "1"
+        }
+        JSON
+          echo "No secret available (likely a fork PR) — using a placeholder google-services.json."
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A new push to the same PR makes the previous run irrelevant.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Guards against a tampered gradle-wrapper.jar, which would otherwise execute
+  # unreviewed code on every runner and developer machine.
+  wrapper:
+    name: Gradle wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: gradle/actions/wrapper-validation@v4
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-android
+        with:
+          google-services-json-base64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+
+      - name: Assemble debug
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+          retention-days: 14
+
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-android
+        with:
+          google-services-json-base64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --stacktrace
+
+      # Reports are what make a red run diagnosable, so keep them even on failure.
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: '**/build/reports/tests/'
+          if-no-files-found: ignore
+          retention-days: 14
+
+  lint:
+    name: Android lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-android
+        with:
+          google-services-json-base64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+
+      - name: Run lint
+        run: ./gradlew lintDebug --stacktrace
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: '**/build/reports/lint-results-*.html'
+          if-no-files-found: ignore
+          retention-days: 14
+
+  release-metadata:
+    name: Release metadata
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check version metadata is in sync
+        run: python3 scripts/check_release_metadata.py

--- a/core/ui/src/main/res/values-zh/strings.xml
+++ b/core/ui/src/main/res/values-zh/strings.xml
@@ -28,6 +28,9 @@
     <string name="sign_out">退出登录</string>
     <string name="all_fields_required">所有字段为必填项</string>
     <string name="sign_in_failed">登录失败</string>
+    <string name="access_token_label">访问令牌</string>
+    <string name="use_access_token">使用访问令牌</string>
+    <string name="use_password">使用密码</string>
     <string name="not_authenticated">未登录</string>
     <string name="server_version">服务器版本</string>
 

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,10 +1,9 @@
-v1.2.0 — Share photos and videos, plus an important image fix.
+v1.2.0 — Share photos and videos, plus an image fix.
 
 New:
-- Share images and videos to Memosly from any app — Memosly now shows up in the share sheet for pictures and video, not just text. Share several at once (up to 9); they upload straight into a new memo.
-- Files over 32 MB are refused up front with a clear message instead of failing mid-upload. This matches the Memos server's own default upload limit.
+- Share images and videos to Memosly from any app, up to 9 at once. They upload straight into a new memo.
+- Files over 32 MB are refused up front instead of failing mid-upload.
 
 Fixed:
-- Images added in the editor never showed up on Memos server v0.25/v0.26. They uploaded fine but were linked to no memo, leaving the file on the server and invisible everywhere. This affected every image added through the editor and has been broken since v1.1.1. If you have images that went missing, re-add them and they will stick.
-- Sharing several files at once could silently drop some of them.
-- A share that arrived while the editor was already open could resurface later and attach itself to an unrelated memo.
+- Images added in the editor never appeared on Memos server v0.25/v0.26 — they uploaded but linked to no memo, leaving the file invisible. Broken since v1.1.1; re-add any that went missing.
+- Sharing several files at once could silently drop some.

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Check that the release metadata scattered across the repo agrees with itself.
+
+A release touches four places, and nothing but care keeps them in sync:
+
+  app/build.gradle.kts                                versionCode / versionName
+  fastlane/metadata/android/{locale}/changelogs/N.txt store changelog, named by versionCode
+  version.json                                        what the in-app update check reads
+  CHANGELOG.md                                        the human history
+
+Getting one wrong is quiet: a missing changelogs/N.txt just means the store shows
+nothing, and a stale version.json prompts every user to "update" to what they have.
+
+Run with no arguments from the repo root. Exits non-zero on the first failure.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Both F-Droid and Play cap a changelog at 500 characters and truncate past it.
+CHANGELOG_LIMIT = 500
+
+LOCALES = ("en-US", "zh-CN")
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+class Failures(list):
+    def check(self, ok: bool, message: str) -> bool:
+        if not ok:
+            self.append(message)
+        return ok
+
+
+def read_version() -> tuple[int, str]:
+    text = (REPO / "app/build.gradle.kts").read_text()
+    code = re.search(r"versionCode\s*=\s*(\d+)", text)
+    name = re.search(r'versionName\s*=\s*"([^"]+)"', text)
+    if not code or not name:
+        sys.exit("could not parse versionCode/versionName out of app/build.gradle.kts")
+    return int(code.group(1)), name.group(1)
+
+
+def main() -> int:
+    version_code, version_name = read_version()
+    print(f"versionCode={version_code} versionName={version_name}")
+    f = Failures()
+
+    # Store changelogs are named by versionCode, so a bump needs a new file per locale.
+    for locale in LOCALES:
+        path = REPO / f"fastlane/metadata/android/{locale}/changelogs/{version_code}.txt"
+        if not f.check(path.exists(), f"missing {path.relative_to(REPO)} for versionCode {version_code}"):
+            continue
+        body = path.read_text()
+        f.check(body.strip() != "", f"{path.relative_to(REPO)} is empty")
+        f.check(
+            len(body) <= CHANGELOG_LIMIT,
+            f"{path.relative_to(REPO)} is {len(body)} chars, over the {CHANGELOG_LIMIT} store limit",
+        )
+
+    # version.json is fetched from main by the in-app update check — if it disagrees
+    # with versionName, users are told to update to a version that does not exist.
+    version_json = REPO / "version.json"
+    try:
+        data = json.loads(version_json.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        f.append(f"version.json is unreadable: {e}")
+    else:
+        f.check(
+            data.get("version") == version_name,
+            f"version.json says {data.get('version')!r}, app/build.gradle.kts says {version_name!r}",
+        )
+        for field in ("release_notes", "release_notes_zh"):
+            f.check(bool(data.get(field, "").strip()), f"version.json has no {field}")
+
+    changelog = (REPO / "CHANGELOG.md").read_text()
+    f.check(
+        f"## [{version_name}]" in changelog,
+        f"CHANGELOG.md has no '## [{version_name}]' section",
+    )
+    f.check(
+        re.search(rf"^\[{re.escape(version_name)}\]:\s*http", changelog, re.M) is not None,
+        f"CHANGELOG.md has no '[{version_name}]: <url>' link reference at the bottom",
+    )
+
+    if f:
+        print("\nrelease metadata is out of sync:", file=sys.stderr)
+        for problem in f:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print("release metadata is consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The repo had no PR checks — `release.yml` only runs on a tag, so nothing stood between a pull request and `main`.
v1.2.0 shipped two bugs that had been sitting in released code for two months, and both were found by hand.

## Jobs

Each is a separate signal, so a red run says what broke.

| job | what it does |
|---|---|
| `wrapper` | validates `gradle-wrapper.jar` against known checksums |
| `build` | `assembleDebug`, uploads the APK |
| `test` | `testDebugUnitTest`, uploads reports even on failure |
| `lint` | `lintDebug`, uploads HTML reports even on failure |
| `release-metadata` | `scripts/check_release_metadata.py` |

## The metadata check

A release has to agree across four places, and every way of getting it wrong is quiet:

- `app/build.gradle.kts` — versionCode / versionName
- `fastlane/metadata/android/{locale}/changelogs/N.txt` — named by versionCode; a missing file shows the store nothing
- `version.json` — read by the in-app update check; stale means every user is told to "update" to what they already run
- `CHANGELOG.md` — section + link reference

Cutting v1.2.0 by hand needed all four kept in step, and the changelog **still** went out at 948 chars against the
stores' 500-char cap. Runs locally too: `python3 scripts/check_release_metadata.py`

## Two existing violations this surfaced

Adding the checks immediately caught real problems, both fixed in their own commits here:

- **`lintDebug` fails on the current tree** — `access_token_label`, `use_access_token`, `use_password` have no `zh`
  entry, so the auth screen's token/password toggle renders in English on Chinese devices. This is why lint couldn't
  just be switched on.
- **the v1.2.0 en-US changelog was 948 chars**, nearly double the store limit — it would have been truncated
  mid-sentence. Every other changelog in the repo is 104-379.

## Fork PRs

`google-services.json` is gitignored but the plugin needs it to configure, so the setup action writes a placeholder
when the secret isn't readable — otherwise every fork PR would fail before compiling. Nothing in CI talks to Firebase.
Verified by building against the placeholder with the real file moved aside.

Gradle cache is read-only off `main`, so a PR can't poison what `main` restores.

## Verification

- `assembleDebug` + `testDebugUnitTest` + `lintDebug` all green locally **against the placeholder** google-services.json
- metadata script negative-tested: exits 1 on a version.json mismatch, on a versionCode with no changelog, and on an
  over-length changelog; exits 0 once restored
- and this PR is the check's own first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ9mXqLfk6PKwo8V9pVDEC